### PR TITLE
Permit floating point maxruns

### DIFF
--- a/ftpbench/ftpbench.py
+++ b/ftpbench/ftpbench.py
@@ -395,7 +395,7 @@ def main():
         opts["password"] = arguments["--password"]
         opts["concurrent"] = int(arguments["--concurrent"])
         opts["timeout"] = int(arguments["--timeout"])
-        opts["maxrun"] = int(arguments["--maxrun"])
+        opts["maxrun"] = float(arguments["--maxrun"])
         opts["size"] = int(arguments["--size"])
         opts["workdir"] = arguments["<workdir>"]
         opts["csvfilename"] = arguments["--csv"]


### PR DESCRIPTION
Integers still accepted.

When testing that a ftpbench connects, one might do <1 minute.